### PR TITLE
Fix for Python 2.6

### DIFF
--- a/pipstrap.py
+++ b/pipstrap.py
@@ -41,7 +41,7 @@ except ImportError:
             cmd = kwargs.get("args")
             if cmd is None:
                 cmd = popenargs[0]
-            raise CalledProcessError(retcode, cmd, output=output)
+            raise CalledProcessError(retcode, cmd)
         return output
 from sys import exit, version_info
 from tempfile import mkdtemp


### PR DESCRIPTION
This PR introduces a fix for Python 2.6.

As this link shows, https://docs.python.org/2/library/subprocess.html#subprocess.CalledProcessError, the ``output`` parameter was introduced with ``check_output`` itself, which isn't supported in Python 2.6.

This PR is related to https://github.com/letsencrypt/letsencrypt/pull/2715