### PR TITLE
Use --no-cache-dir

### DIFF
--- a/pipstrap.py
+++ b/pipstrap.py
@@ -142,7 +142,7 @@ def main():
     try:
         downloads = [hashed_download(url, temp, digest)
                      for url, digest in PACKAGES]
-        check_output('pip install --no-index --no-deps -U ' +
+        check_output('pip install --no-index --no-deps --no-cache-dir -U ' +
                      ' '.join(quote(d) for d in downloads),
                      shell=True)
     except HashError as exc:

--- a/pipstrap.py
+++ b/pipstrap.py
@@ -138,11 +138,16 @@ def main():
     if pip_version >= min_pip_version:
         return 0
 
+    # A cache that is used by default was added in pip 6.0
+    min_cache_version = StrictVersion('6.0')
+    pip_cache = pip_version >= min_cache_version
+
     temp = mkdtemp(prefix='pipstrap-')
     try:
         downloads = [hashed_download(url, temp, digest)
                      for url, digest in PACKAGES]
-        check_output('pip install --no-index --no-deps --no-cache-dir -U ' +
+        check_output('pip install --no-index --no-deps -U ' +
+                     ('--no-cache-dir ' if pip_cache else '') +
                      ' '.join(quote(d) for d in downloads),
                      shell=True)
     except HashError as exc:


### PR DESCRIPTION
This prevents warnings from being displayed if pip would otherwise disable the cache due to incorrect permissions like those seen in https://github.com/certbot/certbot/issues/4938. This is important for certbot-auto as us rerunning the entire script with sudo can often cause these errors from being displayed. The performance hit for not caching these few packages should be very minimal.