### PR TITLE
Update pip version to 9.0.1.

### DIFF
--- a/pipstrap.py
+++ b/pipstrap.py
@@ -57,7 +57,7 @@ except ImportError:
 
 
 __version__ = 1, 2, 0
-PIP_VERSION = '8.0.3'
+PIP_VERSION = '9.0.1'
 
 
 # wheel has a conditional dependency on argparse:
@@ -71,11 +71,11 @@ maybe_argparse = (
 
 PACKAGES = maybe_argparse + [
     # Pip has no dependencies, as it vendors everything:
-    ('https://pypi.python.org/packages/22/f3/'
-     '14bc87a4f6b5ec70b682765978a6f3105bf05b6781fa97e04d30138bd264/'
+    ('https://pypi.python.org/packages/11/b6/'
+     'abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/'
      'pip-{}.tar.gz'
      .format(PIP_VERSION),
-     '30f98b66f3fe1069c529a491597d34a1c224a68640c82caf2ade5f88aa1405e8'),
+     '09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'),
     # This version of setuptools has only optional dependencies:
     ('https://pypi.python.org/packages/69/65/'
      '4c544cde88d4d876cdf5cbc5f3f15d02646477756d89547e9a7ecd6afa76/'


### PR DESCRIPTION
Fixes #12.

pip still vendors all dependencies as stated by a previous inline comment. I've tested this successfully on 14 different systems.

@erikrose, for your Certbot work, if you can prioritize reviewing this and the subsequent PR to Certbot to bring this change into its tree so it's ready in time for the release, that'd be great.