### PR TITLE
Don't install packages in two steps

### DIFF
--- a/pipstrap.py
+++ b/pipstrap.py
@@ -70,14 +70,11 @@ maybe_argparse = (
     if version_info < (2, 7, 0) else [])
 
 
-# Pip has no dependencies, as it vendors everything:
-PIP_PACKAGE = [
+PACKAGES = maybe_argparse + [
+    # Pip has no dependencies, as it vendors everything:
     ('11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/'
      'pip-{0}.tar.gz'.format(PIP_VERSION),
-     '09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d')]
-
-
-OTHER_PACKAGES = maybe_argparse + [
+     '09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d'),
     # This version of setuptools has only optional dependencies:
     ('59/88/2f3990916931a5de6fa9706d6d75eb32ee8b78627bb2abaab7ed9e6d0622/'
      'setuptools-29.0.1.tar.gz',
@@ -162,21 +159,16 @@ def main():
     index_base = get_index_base()
     temp = mkdtemp(prefix='pipstrap-')
     try:
-        # We download and install pip first, then the rest, to avoid the bug
-        # https://github.com/certbot/certbot/issues/4938.
-        pip_downloads, other_downloads = [
-            [hashed_download(index_base + '/packages/' + path,
-                             temp,
-                             digest)
-             for path, digest in packages]
-            for packages in (PIP_PACKAGE, OTHER_PACKAGES)]
-        for downloads in (pip_downloads, other_downloads):
-            check_output('pip install --no-index --no-deps -U ' +
-                         # Disable cache since we're not using it and it
-                         # otherwise sometimes throws permission warnings:
-                         ('--no-cache-dir ' if has_pip_cache else '') +
-                         ' '.join(quote(d) for d in downloads),
-                         shell=True)
+        downloads = [hashed_download(index_base + '/packages/' + path,
+                                     temp,
+                                     digest)
+                     for path, digest in PACKAGES]
+        check_output('pip install --no-index --no-deps -U ' +
+                     # Disable cache since we're not using it and it otherwise
+                     # sometimes throws permission warnings:
+                     ('--no-cache-dir ' if has_pip_cache else '') +
+                     ' '.join(quote(d) for d in downloads),
+                     shell=True)
     except HashError as exc:
         print(exc)
     except Exception:


### PR DESCRIPTION
Remember https://github.com/erikrose/pipstrap/pull/13 and https://github.com/certbot/certbot/issues/4938? We're [just now taking those changes into letsencrypt-auto](https://github.com/certbot/certbot/commit/f1b7017c0c632054c61a231f8cd83db092d063fa#diff-28252f337e7bf16636439cebc20f255e) and the change to install packages in two steps is causing problems. In particular, it appears to cause `setuptools` to not be properly upgraded on older systems such as Debian Wheezy (which while ancient, is still supported by us and Debian).

To try make seeing this as easy as possible, I made a Dockerfile:
```
FROM debian:7

WORKDIR /opt/pipstrap

RUN apt-get update && \
    apt-get install git python-virtualenv -y && \
    git clone https://github.com/erikrose/pipstrap && \
    virtualenv --no-site-packages venv
```
If you build an image based on the Dockerfile, you can see the problem like this:
```
root@5f07af138588:/opt/pipstrap# . ./venv/bin/activate && python pipstrap/pipstrap.py && python -c 'import setuptools; print setuptools.__version__'
0.6
```
You can also see this PR fixes the problem:
```
root@9e004b7f7f61:/opt/pipstrap# cd pipstrap/ && git fetch origin pull/18/head:no-split-install && git checkout no-split-install && cd ..
remote: Counting objects: 3, done.
remote: Total 3 (delta 2), reused 3 (delta 2), pack-reused 0
Unpacking objects: 100% (3/3), done.
From https://github.com/erikrose/pipstrap
 * [new ref]         refs/pull/18/head -> no-split-install
Switched to branch 'no-split-install'
root@9e004b7f7f61:/opt/pipstrap# . ./venv/bin/activate && python pipstrap/pipstrap.py && python -c 'import setuptools; print setuptools.__version__'
29.0.1
```
While https://github.com/certbot/certbot/issues/4938 affected a lot of people, [Ubuntu fixed the problem on their end](https://github.com/certbot/certbot/issues/4938#issuecomment-318426254), since then no one has complained about the lack of a fix from us, and attempting to fix it is causing new issues. When `letsencrypt-auto` tries to run Certbot with this ancient version of `setuptools`, it's unable to find its plugins.

@erikrose, if you can prioritize reviewing this, I'd appreciate it as this is blocking me doing a Certbot release.