### PR TITLE
Ensure to execute pip module attached to the current python environment

### DIFF
--- a/pipstrap.py
+++ b/pipstrap.py
@@ -45,7 +45,7 @@ except ImportError:
                 cmd = popenargs[0]
             raise CalledProcessError(retcode, cmd)
         return output
-from sys import exit, version_info
+from sys import exit, version_info, executable
 from tempfile import mkdtemp
 try:
     from urllib2 import build_opener, HTTPHandler, HTTPSHandler
@@ -150,7 +150,7 @@ def get_index_base():
 
 
 def main():
-    pip_version = StrictVersion(check_output(['pip', '--version'])
+    pip_version = StrictVersion(check_output([executable, '-m', 'pip', '--version'])
                                 .decode('utf-8').split()[1])
     min_pip_version = StrictVersion(PIP_VERSION)
     if pip_version >= min_pip_version:
@@ -163,7 +163,7 @@ def main():
                                      temp,
                                      digest)
                      for path, digest in PACKAGES]
-        check_output('pip install --no-index --no-deps -U ' +
+        check_output('{0} -m pip install --no-index --no-deps -U '.format(executable) +
                      # Disable cache since we're not using it and it otherwise
                      # sometimes throws permission warnings:
                      ('--no-cache-dir ' if has_pip_cache else '') +

--- a/pipstrap.py
+++ b/pipstrap.py
@@ -163,7 +163,7 @@ def main():
                                      temp,
                                      digest)
                      for path, digest in PACKAGES]
-        check_output('{0} -m pip install --no-index --no-deps -U '.format(executable) +
+        check_output('{0} -m pip install --no-index --no-deps -U '.format(quote(executable)) +
                      # Disable cache since we're not using it and it otherwise
                      # sometimes throws permission warnings:
                      ('--no-cache-dir ' if has_pip_cache else '') +


### PR DESCRIPTION
Current `pipstrap` module relies on executing the `pip` wrapper available in PATH. This will work most of the time, in particular if it is called from the main python environment, or from a virtual environment correctly activated with `source venv/bin/activate` to replace correctly `pip` in PATH.

But it will lead to inconsistent behaviors if `pipstrap` is executed directly, like `venv/bin/python pipstrap.py`, because in this case, the `pip` wrapper will still be the one from the main environment, not the virtual environment.

This PR ensures to use the correct `pip` module, by invoking it as a module from the `python` command line, and by resolving `python` through `os.executable`, that takes into account virtual environment triggered by a direct call to `venv/bin/python`.